### PR TITLE
fix: update /tool and /log prompts for modryn-studio-v2 consistency

### DIFF
--- a/.github/prompts/log.prompt.md
+++ b/.github/prompts/log.prompt.md
@@ -19,12 +19,20 @@ Then:
      title: ""
      date: "YYYY-MM-DD"
      tag: ""
+     seoTitle: ""
+     description: ""
      ---
      ```
-     The `tag` field must be the project slug. Use:
-     - `meta` — process/workflow/how-I-work posts
-     - the project slug (e.g. `project-loom`, `trend-detector`) — for anything specific to this project
-         Ask Luke which tag to use if it isn't obvious.
+     The `tag` field must be exactly one of these four values:
+     - `launch` — first public post about a tool (new product announcement, v1/v2 ship)
+     - `build` — work-in-progress updates, decisions, system/architecture posts, how-I-work posts
+     - `milestone` — significant pipeline or infrastructure milestone (e.g. "pipeline is running", "briefings are public")
+     - `learning` — reflections, lessons learned, post-mortems
+
+     The `seoTitle` is the `<title>` tag. Format: `[descriptive hook] | Build Log`. 50–70 characters. More specific than the post title — lead with the outcome or insight, not the project name.
+
+     The `description` is the meta description. 110–160 characters. What happened and why it matters.
+
    - Post body:
 
      **What shipped** — bullet list of the 3–5 most significant things as human outcomes. Not "feat: add X" but "X is now live".

--- a/.github/prompts/tool.prompt.md
+++ b/.github/prompts/tool.prompt.md
@@ -9,22 +9,25 @@ You are in a project repo that is not `modryn-studio/modryn-studio-v2`. Register
 Ask for the following if not already provided:
 
 1. **Name** — display name of the tool
-2. **Description** — one sentence. What it does, who it's for.
-3. **Status** — one of: `live`, `beta`, `building`, `coming-soon`
-4. **URL** — (optional) external URL if the tool lives at a separate domain
-5. **Screenshots** — Check if `public/screenshots/<slug>-light.png` and `public/screenshots/<slug>-dark.png` exist in the current repo (use the slug derived in the step below).
+2. **Tagline** — one sentence, outcome-focused. What the user gets, not what the tech does. Displayed in amber on the tool page below the title. Example: "Context files for your AI coding tool"
+3. **Description** — one to two sentences. More detail about who it's for and what problem it solves. Used in metadata and the tool card.
+4. **Bullets** — (optional) 3–5 short bullets showing the key features or steps. Displayed as a list on the tool page. Example: `["Describe your idea in plain English", "Answer 13 questions", "Download in 60 seconds"]`
+5. **Status** — one of: `live`, `beta`, `building`, `coming-soon`
+6. **URL** — (optional) external URL if the tool lives at a separate domain
+7. **Screenshots** — Check if `public/screenshots/<slug>-light.png` and `public/screenshots/<slug>-dark.png` exist in the current repo (use the slug derived in the step below).
    - If both exist: use them. Commit any uncommitted screenshots before opening the PR.
    - If only one exists: use it for `screenshotUrl` only.
    - If neither exists: ask the user to drop screenshots into `public/screenshots/`. Preferred: `<slug>-light.png` + `<slug>-dark.png`. A single `<slug>.gif` is also accepted for an animated preview.
    - Derive public URLs from the tool's `url` hostname: `https://<domain>/screenshots/<slug>-light.png` (light) and `https://<domain>/screenshots/<slug>-dark.png` (dark).
    - Set `screenshotUrl` = light URL, `screenshotUrlDark` = dark URL (omit `screenshotUrlDark` if no dark variant exists).
-6. **Logo URL** — (optional) public URL to the tool's square logomark (transparent background, ideally 40×40 or larger). Default to:
-   - `https://<domain>/icon.png` if the tool is deployed on its own domain
-   - `https://modrynstudio.com/tools/<slug>/icon.png` for modryn-hosted tools
-   - Omit the field entirely if no logomark exists yet.
-7. **Launched date** — (optional, only if status is `live` or `beta`) ISO date, e.g. `2026-03-01`
-8. **Log slug** — (optional) slug of the `/log` post documenting this build
-9. **Target subreddits** — (optional) 2–4 subreddits where the tool's target users hang out. Used by the `/social` prompt for launch-day distribution. Don't include r/SideProject (always included as founder channel). Example: `["r/webdev", "r/freelance"]`
+8. **Logo** — (optional) the tool's square logomark (transparent background, ideally 40×40 or larger).
+   - Default icon URL to try: `https://<domain>/icon.png`
+   - Fetch the icon as binary and push it to `public/logos/<slug>.png` on the PR branch in `modryn-studio/modryn-studio-v2` using the GitHub MCP
+   - Set `logoUrl` to `/logos/<slug>.png`
+   - If the icon cannot be fetched or the URL is unknown, omit `logoUrl` and note it in the PR body
+9. **Launched date** — (optional, only if status is `live` or `beta`) ISO date, e.g. `2026-03-01`
+10. **Log slug** — (optional) slug of the `/log` post documenting this build
+11. **Target subreddits** — (optional) 2–4 subreddits where the tool's target users hang out. Used by the `/social` prompt for launch-day distribution. Don't include r/SideProject (always included as founder channel). Example: `["r/webdev", "r/freelance"]`
 
 Then:
 - Derive the slug from the name (lowercase, spaces → hyphens, strip special chars)


### PR DESCRIPTION
Fixes gaps that would cause `/tool` and `/log` to produce inconsistent output vs. what modryn-studio-v2 now expects.

## `/tool` changes
- **Add `tagline` question** — one sentence, outcome-focused. Displayed in amber on the tool page. Was missing entirely.
- **Add `bullets` question** — optional 3–5 bullets. Displayed as a list on the tool page. Was missing entirely.
- **Logo is now local** — instead of `logoUrl: "https://<domain>/icon.png"`, the agent now fetches the icon binary and pushes it to `public/logos/<slug>.png` on the PR branch, then sets `logoUrl: "/logos/<slug>.png"`. Prevents broken logos on CDN changes and offline.

## `/log` changes
- **Tag system replaced** — was: `meta` or the project slug. Now: exactly one of `launch` / `build` / `milestone` / `learning`.
- **`seoTitle` added to frontmatter template** — required on every post. Format: `[descriptive hook] | Build Log`. 50–70 chars.
- **`description` added to frontmatter template** — required for metadata. 110–160 chars.